### PR TITLE
Add options to include topic metadata and offsets in list

### DIFF
--- a/commands/list/topics.go
+++ b/commands/list/topics.go
@@ -21,6 +21,7 @@ type topics struct {
 	kafkaParams  *commands.KafkaParameters
 	globalParams *commands.GlobalParameters
 	topicFilter  *regexp.Regexp
+	loadConfigs  bool
 	format       string
 	style        string
 }
@@ -34,6 +35,9 @@ func addTopicsSubCommand(parent *kingpin.CmdClause, global *commands.GlobalParam
 	c.Flag("topic-filter", "An optional regular expression to filter the topics by.").
 		Short('t').
 		RegexpVar(&cmd.topicFilter)
+	c.Flag("load-config", "Loads the topic's configurations from the server.").
+		NoEnvar().
+		Short('c').BoolVar(&cmd.loadConfigs)
 	commands.AddFormatFlag(c, &cmd.format, &cmd.style)
 }
 
@@ -49,7 +53,7 @@ func (c *topics) run(_ *kingpin.ParseContext) error {
 		cancel()
 	}()
 
-	topics, err := manager.GetTopics(ctx, c.topicFilter)
+	topics, err := manager.GetTopics(ctx, c.topicFilter, c.loadConfigs)
 	if err != nil {
 		return err
 	}

--- a/commands/list/topics.go
+++ b/commands/list/topics.go
@@ -18,12 +18,13 @@ import (
 )
 
 type topics struct {
-	kafkaParams  *commands.KafkaParameters
-	globalParams *commands.GlobalParameters
-	topicFilter  *regexp.Regexp
-	loadConfigs  bool
-	format       string
-	style        string
+	kafkaParams    *commands.KafkaParameters
+	globalParams   *commands.GlobalParameters
+	topicFilter    *regexp.Regexp
+	loadConfigs    bool
+	includeOffsets bool
+	format         string
+	style          string
 }
 
 func addTopicsSubCommand(parent *kingpin.CmdClause, global *commands.GlobalParameters, kafkaParams *commands.KafkaParameters) {
@@ -38,6 +39,9 @@ func addTopicsSubCommand(parent *kingpin.CmdClause, global *commands.GlobalParam
 	c.Flag("load-config", "Loads the topic's configurations from the server.").
 		NoEnvar().
 		Short('c').BoolVar(&cmd.loadConfigs)
+	c.Flag("include-offsets", "Queries the server to read the latest available offset of each partition.").
+		NoEnvar().
+		Short('o').BoolVar(&cmd.includeOffsets)
 	commands.AddFormatFlag(c, &cmd.format, &cmd.style)
 }
 
@@ -53,7 +57,7 @@ func (c *topics) run(_ *kingpin.ParseContext) error {
 		cancel()
 	}()
 
-	topics, err := manager.GetTopics(ctx, c.topicFilter, c.loadConfigs)
+	topics, err := manager.GetTopics(ctx, c.topicFilter, c.loadConfigs, c.includeOffsets)
 	if err != nil {
 		return err
 	}

--- a/kafka/manager.go
+++ b/kafka/manager.go
@@ -191,7 +191,7 @@ func (m *Manager) DescribeCluster(ctx context.Context, includeConfig bool) (*Clu
 }
 
 // GetTopics returns a list of all the topics on the server.
-func (m *Manager) GetTopics(ctx context.Context, filter *regexp.Regexp, includeConfig bool) ([]Topic, error) {
+func (m *Manager) GetTopics(ctx context.Context, filter *regexp.Regexp, includeConfig, includeOffsets bool) ([]Topic, error) {
 	m.Log(internal.Verbose, "Retrieving topic list from the server")
 	topics, err := m.admin.ListTopics()
 	if err != nil {
@@ -215,7 +215,7 @@ func (m *Manager) GetTopics(ctx context.Context, filter *regexp.Regexp, includeC
 				ReplicationFactor:  details.ReplicationFactor,
 			}
 			if includeConfig {
-				meta, err := m.DescribeTopic(ctx, topic, includeConfig, includeConfig)
+				meta, err := m.DescribeTopic(ctx, topic, includeConfig, includeOffsets)
 				if err == nil {
 					t.Metadata = meta
 

--- a/kafka/manager.go
+++ b/kafka/manager.go
@@ -191,7 +191,7 @@ func (m *Manager) DescribeCluster(ctx context.Context, includeConfig bool) (*Clu
 }
 
 // GetTopics returns a list of all the topics on the server.
-func (m *Manager) GetTopics(ctx context.Context, filter *regexp.Regexp) ([]Topic, error) {
+func (m *Manager) GetTopics(ctx context.Context, filter *regexp.Regexp, includeConfig bool) ([]Topic, error) {
 	m.Log(internal.Verbose, "Retrieving topic list from the server")
 	topics, err := m.admin.ListTopics()
 	if err != nil {
@@ -209,11 +209,19 @@ func (m *Manager) GetTopics(ctx context.Context, filter *regexp.Regexp) ([]Topic
 				m.Logf(internal.SuperVerbose, "Filtering out %s topic", topic)
 				continue
 			}
-			result = append(result, Topic{
+			t := Topic{
 				Name:               topic,
 				NumberOfPartitions: details.NumPartitions,
 				ReplicationFactor:  details.ReplicationFactor,
-			})
+			}
+			if includeConfig {
+				meta, err := m.DescribeTopic(ctx, topic, includeConfig, includeConfig)
+				if err == nil {
+					t.Metadata = meta
+
+				}
+			}
+			result = append(result, t)
 		}
 	}
 	return result, nil

--- a/kafka/topic.go
+++ b/kafka/topic.go
@@ -10,6 +10,8 @@ type Topic struct {
 	NumberOfPartitions int32 `json:"number_of_partitions"`
 	// ReplicationFactor replication factor.
 	ReplicationFactor int16 `json:"replication_factor"`
+	// Topic metadata.
+	Metadata           *TopicMetadata `json:"metadata"`
 }
 
 // TopicsByName sorts the topic list by name.


### PR DESCRIPTION
Today I needed to review the retentions configured for all our topics. Rather than iterating over all the topics with the shell I thought it might make sense to have the `list` command grab the metadata too. I added `-c` and `-o` options, same as `describe`, that causes it to grab the config and offsets and stick it into a `Metadata` field. 

Right now it only shows up in the `json` output, which probably makes sense, since the table would be unwieldy with all the metadata (but it would be really nice to be able to choose columns of interest).

You may have some better idea or preference on how this is done, I'm open to ideas, but this met my need so I wanted to offer it back.

Example usage:
```
$ trubka list topics  -c -t ingest\.dcache\.billing -f json | \
jq -c '.[] | {"name":.name, "retention_days":(.metadata.configurations | from_entries | ."retention.ms" | tonumber /1000/3600/24)}'
{"name":"ingest.dcache.billing","retention_days":7}
{"name":"ingest.dcache.billing.cms-disk","retention_days":7}
{"name":"ingest.dcache.billing.cms-tape","retention_days":30}
```