### PR TITLE
Fix missing quote in boolean parsing regex

### DIFF
--- a/commands/produce/template/parser.go
+++ b/commands/produce/template/parser.go
@@ -362,7 +362,7 @@ func (t *Parser) replaceExtraGenerators(value string) string {
 			},
 		},
 		{
-			ex: regexp.MustCompile(`"\s*Bool\(\)\s*|BoolS\(\)`),
+			ex: regexp.MustCompile(`"\s*Bool\(\)\s*"|BoolS\(\)`),
 			replacer: func(match string) string {
 				return gofakeit.RandString([]string{"true", "false"})
 			},


### PR DESCRIPTION
I was trying to generate a boolean value, and I was getting an error, after checking the source code I could see what it was a bug. One missing quote is missing from the boolean regex, as a result the produced output still had the quote, producing an invalid JSON document