### PR TITLE
chore: update Go to 1.24.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15.5
+          go-version: 1.24.2
       - name: Check out code
         uses: actions/checkout@v2
       - name: Download dependencies
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15.5
+          go-version: 1.24.2
       - name: Check out code
         uses: actions/checkout@v2
       - name: Download dependencies
@@ -100,7 +100,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15.5
+          go-version: 1.24.2
       - name: Check out code
         uses: actions/checkout@v2
       - name: Download dependencies

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/xitonix/trubka
 
-go 1.15
+go 1.24.2
 
 require (
 	github.com/Shopify/sarama v1.27.2


### PR DESCRIPTION
Release failed because Go was too old.

https://github.com/xitonix/trubka/actions/runs/14501646419/job/40682515658

```
Run actions/setup-go@v2
Setup go stable version spec 1.15.5
Attempting to download 1.[15](https://github.com/xitonix/trubka/actions/runs/14501646419/job/40682515658#step:2:16).5...
matching 1.15.5...
Not found in manifest.  Falling back to download directly from Go
Error: Unable to find Go version '1.15.5' for platform darwin and architecture arm64.
```

Go's latest version is 1.24.2.
Go 1.22 or older isn't supported officially anymore.

trubka is a CLI, not Go library, so we should update Go to the latest version.